### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Make Real
+
+AI-powered image generation app built on tldraw SDK + Next.js 14.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+Single Next.js app (frontend + API routes). No database, no Docker.
+
+- **Dev server**: `pnpm run dev` (port 3000)
+- **Lint**: `pnpm run lint`
+- **Build**: `pnpm run build`
+
+### Environment
+
+- Requires **Node.js 20** (devcontainer spec). Use `nvm use 20` if needed.
+- Package manager: **pnpm** (lockfile: `pnpm-lock.yaml`).
+- After `pnpm install`, run `pnpm rebuild sharp` if sharp's postinstall was skipped by pnpm's build-script policy.
+
+### API keys
+
+The "Make Real" and "Style Transfer" features call external APIs. To test those features end-to-end, create `.env.local` with:
+
+```
+REPLICATE_API_TOKEN=...
+FAL_KEY=...
+COMFYICU_API_KEY=...
+```
+
+The dev server and canvas work fine without these keys; only the AI generation buttons require them.
+
+### Key files
+
+- `app/prompt.ts` — prompt sent to the AI model
+- `app/lib/makeReal.tsx` — logic for the "Make Real" button
+- `app/PreviewShape/PreviewShape.tsx` — custom tldraw shape for previews
+- `app/api/generate-single-image/route.ts` — Replicate API route
+- `app/api/style-transfer/route.ts` — fal.ai + comfy.icu API route


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for the Make Real codebase.

## What was set up

- **Node.js 20** via nvm (matching devcontainer spec)
- **pnpm** as package manager (matching `pnpm-lock.yaml`)
- All dependencies installed and `sharp` native module rebuilt

## Verified

| Check | Command | Status |
|-------|---------|--------|
| Lint | `pnpm run lint` | Passed |
| Build | `pnpm run build` | Passed |
| Dev server | `pnpm run dev` | Running on port 3000 |
| Canvas interaction | Draw + select on tldraw canvas | Working |

## Demo

<a href="https://cursor.com/agents/bc-9fc64904-3012-4e6a-bc65-0486d0abf0d0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmake_real_tldraw_canvas_demo.mp4"><img src="https://cursor.com/artifacts/c/art-f63a5b2d-77f1-4732-b241-318944b6a1b4" alt="make_real_tldraw_canvas_demo.mp4" /></a>

tldraw canvas fully interactive — drawing, selecting, and toolbar tools all work.

![Canvas with drawings](https://cursor.com/artifacts/c/art-d47ca8f8-4ee5-415f-b649-b754b98920bd)

## Changes

- Added `AGENTS.md` with cloud-specific environment, service, and key-file documentation for future agents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fc64904-3012-4e6a-bc65-0486d0abf0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fc64904-3012-4e6a-bc65-0486d0abf0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

